### PR TITLE
Update terraform.tfvars.example with more AD variables

### DIFF
--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -19,6 +19,8 @@ EOF
 
 ClusterNameTag = "mycluster"
 
+ManagementAD = "3"
+FilesystemAD = "3"
 InstanceADIndex = ["3"]
 ManagementShape = "VM.Standard1.1"
 ComputeShapes = ["VM.Standard1.2"]


### PR DESCRIPTION
When creating a cluster wholly in AD3 we found some of the variables default to AD1. Putting them in the example file shows us which ones we can override.

Relates to #2 