### PR TITLE
Add VM.GPU2.1 shape.

### DIFF
--- a/files/shapes.yaml
+++ b/files/shapes.yaml
@@ -83,6 +83,13 @@ VM.DenseIO2.24:
   cores_per_socket: 24
   threads_per_core: 2
 
+# VM GPU
+
+VM.GPU2.1: 
+  memory: 71000
+  cores_per_socket: 12 
+  threads_per_core: 2
+
 # Bare metal
 
 BM.Standard1.36:


### PR DESCRIPTION
Adds the VM.GPU2.1 shape to `shapes.yaml`, see #11. 

It would be good to add all VM.GPU* shapes, but I don't have them in my service limits. Is there documentation somewhere where we can extract core and memory information without having to boot up an instance?  
