### PR TITLE
Add dependency of the mgmt node on the filesystem

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -1,4 +1,5 @@
 resource "oci_core_instance" "ClusterManagement" {
+  depends_on          = ["oci_file_storage_export.ClusterFSExport"]
   availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[var.ManagementAD - 1], "name")}"
   compartment_id      = "${var.compartment_ocid}"
   display_name        = "mgmt"


### PR DESCRIPTION
This should mean that the filesystem will remain until the mgmt node is destroyed so that any dangling compute nodes can be terminated.

Fixes #22 